### PR TITLE
Markupsafe cap version at less than 2

### DIFF
--- a/CI/docker/jenkins/Dockerfile
+++ b/CI/docker/jenkins/Dockerfile
@@ -76,7 +76,8 @@ ENV SONAR_SCANNER_OPTS="-server"
 
 COPY CI/docker/jenkins/requirements-ci.txt requirements.txt ./
 COPY --from=wheel_builder /wheels /wheels/
-
+RUN mkdir -p /.cache/pip && \
+    chmod -R 777 /.cache
 RUN python3 -m pip install --no-cache-dir  --find-links=/wheels/ \
     -r requirements-ci.txt \
     -r requirements.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -8232,9 +8232,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mkdirp": {
@@ -16499,9 +16499,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mkdirp": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-flask
+flask<2
 Flask-SQLAlchemy
 jinja2<3.0,>2.0
 lxml
+MarkupSafe<2
 SQLAlchemy>1.4

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ setup(
         "SQLAlchemy>1.4",
         # "mysqlclient",
         "flask",
+        "MarkupSafe<2",
         "Flask-SQLAlchemy",
         "lxml",
         "Jinja2<3.0,>2.0"


### PR DESCRIPTION
Going beyond 2 for marksafe breaks flask because it uses the deprecated soft_unicode which was removed in version 2